### PR TITLE
Added table to select lighter or darker color instead of black and white

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -20,7 +20,7 @@ var Irc = require('irc-framework'),
     reladate = require('relative-date'),
     config = require(process.env.CONFIG_PATH).irc,
     mooseLock = false,
-    mooseParse = /^[.!]*meme(?:me)? (-[^ ]*)? ?(.*)/,
+    mooseParse = /^[.!]*moose(?:me)? (-[^ ]*)? ?(.*)/,
     moosedb,
     logger
 
@@ -277,7 +277,7 @@ module.exports = (moosedb_, logger_) => {
         )
     })
 
-    irc.matchMessage(/^[.!]*meme(me)?/, (event) => {
+    irc.matchMessage(/^[.!]*moose(me)?/, (event) => {
         var parse = event.message
             .match(mooseParse)
         if (!parse) parse = ['', '--random', '']

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -43,6 +43,64 @@ var mooseColor = {
     f: 'silver',
 }
 
+var mooseLightColorShade = {
+    1: 'gray',
+    2: 'blue',
+    3: 'lime',
+    5: 'white',
+    6: 'white',
+    7: 'yellow',
+    a: 'cyan',
+    e: 'silver',
+    f: 'white',
+}
+
+var mooseDarkColorShade = {
+    0: 'silver',
+    4: 'brown',
+    8: 'olive',
+    9: 'green',
+    b: 'teal',
+    c: 'navy',
+    d: 'purple',
+    e: 'black',
+    f: 'gray',
+}
+
+function lightColorPick (color,char,shadeChar) {
+    var light
+    switch (color) {
+    case 'gray': light = colors[mooseColor[char]].bggray(shadeChar); break
+    case 'blue': light = colors[mooseColor[char]].bgblue(shadeChar); break
+    case 'lime': light = colors[mooseColor[char]].bglime(shadeChar); break
+    case 'red': light = colors[mooseColor[char]].bgred(shadeChar); break
+    case 'pink': light = colors[mooseColor[char]].bgpink(shadeChar); break
+    case 'yellow': light = colors[mooseColor[char]].bgyellow(shadeChar); break
+    case 'cyan': light = colors[mooseColor[char]].bgcyan(shadeChar); break
+    case 'silver': light = colors[mooseColor[char]].bgsilver(shadeChar); break
+    case 'white': light = colors[mooseColor[char]].bgwhite(shadeChar); break
+    default: light = false
+    }
+    return light
+}
+
+function darkColorPick (color, char,shadeChar) {
+    var dark
+    switch (color) {
+    case 'silver': dark = colors[mooseColor[char]].bgsilver(shadeChar); break
+    case 'brown': dark = colors[mooseColor[char]].bgbrown(shadeChar); break
+    case 'olive': dark = colors[mooseColor[char]].bgolive(shadeChar); break
+    case 'green': dark = colors[mooseColor[char]].bggreen(shadeChar); break
+    case 'teal': dark = colors[mooseColor[char]].bgteal(shadeChar); break
+    case 'navy': dark = colors[mooseColor[char]].bgnavy(shadeChar); break
+    case 'purple': dark = colors[mooseColor[char]].bgpurple(shadeChar); break
+    case 'black': dark = colors[mooseColor[char]].bgblack(shadeChar); break
+    case 'gray': dark = colors[mooseColor[char]].bggray(shadeChar); break
+    default: dark = false
+    }
+    return dark
+}
+
 var mooseShade = {
     0: '░',
     1: '▒',
@@ -63,10 +121,16 @@ function mooseLine(line, shade) {
             return colors[mooseColor[char]][`bg${mooseColor[char]}`](mooseShade['3'])
         }
         else if (+shade[ind] < 3) {
-            return colors[mooseColor[char]].bgwhite(mooseShade[shade[ind]])
+            if (mooseLightColorShade[char])
+                return lightColorPick(mooseLightColorShade[char],char,mooseShade[shade[ind]])
+            else
+                return colors[mooseColor[char]].bgwhite(mooseShade[shade[ind]])
         }
         else {
-            return colors[mooseColor[char]].bgblack(mooseShade[shade[ind]])
+            if (mooseDarkColorShade[char])
+                return darkColorPick(mooseDarkColorShade[char],char,mooseShade[shade[ind]]) 
+            else
+                return colors[mooseColor[char]].bgblack(mooseShade[shade[ind]])
         }
     }).join('')
 }

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -20,7 +20,7 @@ var Irc = require('irc-framework'),
     reladate = require('relative-date'),
     config = require(process.env.CONFIG_PATH).irc,
     mooseLock = false,
-    mooseParse = /^[.!]*moose(?:me)? (-[^ ]*)? ?(.*)/,
+    mooseParse = /^[.!]*meme(?:me)? (-[^ ]*)? ?(.*)/,
     moosedb,
     logger
 
@@ -44,13 +44,14 @@ var mooseColor = {
 }
 
 var mooseLightColorShade = {
-    1: 'gray',
-    2: 'blue',
+    1: 'silver',
+    2: 'cyan',
     3: 'lime',
     5: 'white',
     6: 'white',
     7: 'yellow',
     a: 'cyan',
+    c: 'cyan',
     e: 'silver',
     f: 'white',
 }
@@ -276,7 +277,7 @@ module.exports = (moosedb_, logger_) => {
         )
     })
 
-    irc.matchMessage(/^[.!]*moose(me)?/, (event) => {
+    irc.matchMessage(/^[.!]*meme(me)?/, (event) => {
         var parse = event.message
             .match(mooseParse)
         if (!parse) parse = ['', '--random', '']

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017  Anthony DeDominic <adedomin@gmail.com>
+ * Copyright (C) 2017  Anthony DeDominic <adedomin@gmail.com>, Underdoge
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -67,40 +67,6 @@ var mooseDarkColorShade = {
     f: 'gray',
 }
 
-function lightColorPick (color,char,shadeChar) {
-    var light
-    switch (color) {
-    case 'gray': light = colors[mooseColor[char]].bggray(shadeChar); break
-    case 'blue': light = colors[mooseColor[char]].bgblue(shadeChar); break
-    case 'lime': light = colors[mooseColor[char]].bglime(shadeChar); break
-    case 'red': light = colors[mooseColor[char]].bgred(shadeChar); break
-    case 'pink': light = colors[mooseColor[char]].bgpink(shadeChar); break
-    case 'yellow': light = colors[mooseColor[char]].bgyellow(shadeChar); break
-    case 'cyan': light = colors[mooseColor[char]].bgcyan(shadeChar); break
-    case 'silver': light = colors[mooseColor[char]].bgsilver(shadeChar); break
-    case 'white': light = colors[mooseColor[char]].bgwhite(shadeChar); break
-    default: light = false
-    }
-    return light
-}
-
-function darkColorPick (color, char,shadeChar) {
-    var dark
-    switch (color) {
-    case 'silver': dark = colors[mooseColor[char]].bgsilver(shadeChar); break
-    case 'brown': dark = colors[mooseColor[char]].bgbrown(shadeChar); break
-    case 'olive': dark = colors[mooseColor[char]].bgolive(shadeChar); break
-    case 'green': dark = colors[mooseColor[char]].bggreen(shadeChar); break
-    case 'teal': dark = colors[mooseColor[char]].bgteal(shadeChar); break
-    case 'navy': dark = colors[mooseColor[char]].bgnavy(shadeChar); break
-    case 'purple': dark = colors[mooseColor[char]].bgpurple(shadeChar); break
-    case 'black': dark = colors[mooseColor[char]].bgblack(shadeChar); break
-    case 'gray': dark = colors[mooseColor[char]].bggray(shadeChar); break
-    default: dark = false
-    }
-    return dark
-}
-
 var mooseShade = {
     0: '░',
     1: '▒',
@@ -122,13 +88,13 @@ function mooseLine(line, shade) {
         }
         else if (+shade[ind] < 3) {
             if (mooseLightColorShade[char])
-                return lightColorPick(mooseLightColorShade[char],char,mooseShade[shade[ind]])
+                return colors[mooseColor[char]][`bg${mooseLightColorShade[char]}`](mooseShade[shade[ind]])
             else
                 return colors[mooseColor[char]].bgwhite(mooseShade[shade[ind]])
         }
         else {
             if (mooseDarkColorShade[char])
-                return darkColorPick(mooseDarkColorShade[char],char,mooseShade[shade[ind]]) 
+                return colors[mooseColor[char]][`bg${mooseDarkColorShade[char]}`](mooseShade[shade[ind]])
             else
                 return colors[mooseColor[char]].bgblack(mooseShade[shade[ind]])
         }


### PR DESCRIPTION
Currently all colors are shaded with white or black blocks regardless of the selected color for the irc output.

This change uses darker or lighter versions of the selected color for the shades used for the irc output, when possible.

For example if cyan is selected, a darker shade uses teal instead of black. Or if yellow is selected, a darker shade uses olive instead of black. No lighter colors for yellow or cyan exist so those use white for the lighter shade as usual.

[Proposed vs current #MAGA!](http://i.imgur.com/nYYQ2MB.png)

[Proposed vs current #MAGA!](http://i.imgur.com/s9dKieB.png)

[Proposed vs current gnite](http://i.imgur.com/jqt9AQF.png)

[Proposed vs current gnite](http://i.imgur.com/cA1TIUM.png)

[Proposed vs current nice eye!](http://i.imgur.com/a0o1vep.png)

[Proposed vs current nice eye!](http://i.imgur.com/fJWKCPh.png)

[Proposed vs current d](http://i.imgur.com/MCig1nZ.png)

[Proposed vs current d](http://i.imgur.com/LO2Dxkt.png)